### PR TITLE
ci(release): use github actions to build and release apk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,82 @@
+name: Build APK and Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.metadata'
+      - '.vscode/**'
+      - '.VSCodeCounter/**'
+      - '.gitignore'
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "17.x"
+          cache: "gradle"
+
+      - name: Setup flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Prepare keystore for signing
+        shell: bash
+        run: |
+          echo "storeFile=keystore.jks" >> android/key.properties
+          echo "keyAlias=${KEY_ALIAS}" >> android/key.properties
+          echo "storePassword=${KEYSTORE_PASSWORD}" >> android/key.properties
+          echo "keyPassword=${KEY_PASSWORD}" >> android/key.properties
+          if [ -n "${KEYSTORE_FILE}" ]; then
+            echo "${KEYSTORE_FILE}" | base64 --decode > android/app/keystore.jks || \
+              (echo "Keystore file error, use debug signature.";rm -f android/key.properties)
+          else
+            echo "No keystore file provided, use debug signature."
+            rm -f android/key.properties
+          fi
+        env:
+          # https://github.com/GoldenglowSusie/MiRearScreenSwitcher/settings/secrets/actions/new
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Build Release APK
+        shell: bash
+        run: |
+          flutter pub get
+          flutter build apk --release --split-per-abi --target-platform android-arm64
+          cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk MRSS-${{ github.ref_name }}-release.apk
+
+      - name: Upload Release APK
+        uses: actions/upload-artifact@v5
+        with:
+          name: app-release-apk
+          path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+
+      - name: Release to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: "${{ github.ref_name }}"
+          # https://github.com/settings/personal-access-tokens/new
+          token: ${{ secrets.PAT }}
+          files: |
+            MRSS-${{ github.ref_name }}-release.apk

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,17 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -36,9 +45,22 @@ android {
         disable.add("Instantiatable")
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
+
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keystorePropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=file\:///C:/Users/16094/Documents/rear_screen_dev/gradle-8.9-all.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.9-all.zip


### PR DESCRIPTION
1. 为当前项目添加自动编译功能：
  * 代码推送到任意branch或tag时，触发自动编译
  * 当推送新tag时，自动发布编译后的apk文件，文件名使用标签名
2. 修改`distributionUrl`为国内在线源，保证国内连接性的同时兼容多人协作开发
3. 修改签名规则`android/app/build.gradle.kts`：如果有自己的签名文件则使用自签名发布，否则使用内置的debug签名发布。[使用参考](https://docs.flutter.dev/deployment/android#create-an-upload-keystore)
4. 打开[secrets](https://github.com/GoldenglowSusie/MiRearScreenSwitcher/settings/secrets/actions/new)页面创建5个`Repository secrets`，名称分别是`KEYSTORE_FILE`、`KEYSTORE_PASSWORD`、`KEY_ALIAS`、`KEY_PASSWORD`、`PAT`
  * `KEYSTORE_FILE`是`keytool`生成的`*.jks`文件的base64编码
  * `PAT`是[fine-grained personal access token](https://github.com/settings/personal-access-tokens/new)，用于写入github release
